### PR TITLE
Fix duplicate settings declaration

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { 
-  Settings, 
+  Settings as SettingsIcon, 
   Bell, 
   Moon, 
   Sun, 
@@ -31,7 +31,7 @@ const Settings: React.FC = () => {
       {/* General Settings */}
       <div className="card">
         <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-          <Settings size={20} />
+          <SettingsIcon size={20} />
           Общие настройки
         </h2>
         


### PR DESCRIPTION
Rename `Settings` icon import to `SettingsIcon` to resolve duplicate declaration error.

---
<a href="https://cursor.com/background-agent?bcId=bc-610e49a8-b7e0-4e7e-9f47-2ae74b867378">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-610e49a8-b7e0-4e7e-9f47-2ae74b867378">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>